### PR TITLE
Update log4j2.xml

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="debug" strict="true" name="XMLConfigTest">
+<Configuration status="info" strict="true" name="XMLConfigTest">
     <Properties>
         <Property name="filename">log/test.log</Property>
     </Properties>


### PR DESCRIPTION
Setting the Configuration status="info" in the log4j2.xml wont spam the logging info to the console.


Configuration status="debug"
![image](https://github.com/fhb-ss24-opro/OPROTemplateSS24/assets/125290988/72cae4f8-2552-44cc-a273-487a66280f91)

Configuration status="info"
![image](https://github.com/fhb-ss24-opro/OPROTemplateSS24/assets/125290988/800b7949-9af0-443f-8f25-a0799418fe9a)
